### PR TITLE
ARC: ptrace: fix instruction_pointer macro for pt_regs structure

### DIFF
--- a/arch/arc/include/asm/ptrace.h
+++ b/arch/arc/include/asm/ptrace.h
@@ -106,7 +106,7 @@ struct callee_regs {
 	long r25, r24, r23, r22, r21, r20, r19, r18, r17, r16, r15, r14, r13;
 };
 
-#define instruction_pointer(regs)	(unsigned long)((regs)->ret)
+#define instruction_pointer(regs)	(*((unsigned long *) &((regs)->ret)))
 #define profile_pc(regs)		instruction_pointer(regs)
 
 /* return 1 if user mode or 0 if kernel mode */


### PR DESCRIPTION
This macro is used in `arch/arc/kernel/kgdb.c` in functions `kgdb_trap` and `kgdb_arch_set_pc` to change value of `pt_regs->ret`. But this macro uses cast operator `(unsigned long)` for the struct's field and then generates rvalue.

    #define instruction_pointer(regs) (unsigned long)((regs)->ret)

Thus an error occurs in `kgdb.c`:

    instruction_pointer(regs) = ip;

It's necessary to use another form of casting `pt_regs->ret` which allows to use macro substitution as lvalue:

    #define ... (*((unsigned long *) &((regs)->ret)))

Seems like this bug was introduced in https://github.com/foss-for-synopsys-dwc-arc-processors/linux/commit/504efa5c1396a56b3a028c53cb71917e21732717.