### PR TITLE
ARCv3: use 64-bit aux read/write for PCT

### DIFF
--- a/arch/arc/kernel/perf_event.c
+++ b/arch/arc/kernel/perf_event.c
@@ -113,8 +113,12 @@ static u64 arc_pmu_read_counter(int idx)
 	write_aux_reg(ARC_REG_PCT_INDEX, idx);
 	tmp = read_aux_reg(ARC_REG_PCT_CONTROL);
 	write_aux_reg(ARC_REG_PCT_CONTROL, tmp | ARC_REG_PCT_CONTROL_SN);
+#ifdef CONFIG_ISA_ARCV3
+	result = read_aux_64(ARC_REG_PCT_SNAPL);
+#else
 	result = (u64) (read_aux_reg(ARC_REG_PCT_SNAPH)) << 32;
 	result |= read_aux_reg(ARC_REG_PCT_SNAPL);
+#endif
 
 	return result;
 }
@@ -277,8 +281,12 @@ static int arc_pmu_event_set_period(struct perf_event *event)
 	write_aux_reg(ARC_REG_PCT_INDEX, idx);
 
 	/* Write value */
+#ifdef CONFIG_ISA_ARCV3
+	write_aux_64(ARC_REG_PCT_COUNTL, value);
+#else
 	write_aux_reg(ARC_REG_PCT_COUNTL, lower_32_bits(value));
 	write_aux_reg(ARC_REG_PCT_COUNTH, upper_32_bits(value));
+#endif
 
 	perf_event_update_userpage(event);
 
@@ -380,10 +388,14 @@ static int arc_pmu_add(struct perf_event *event, int flags)
 
 	if (is_sampling_event(event)) {
 		/* Mimic full counter overflow as other arches do */
+#ifdef CONFIG_ISA_ARCV3
+		write_aux_64(ARC_REG_PCT_INT_CNTL, arc_pmu->max_period);
+#else
 		write_aux_reg(ARC_REG_PCT_INT_CNTL,
 			      lower_32_bits(arc_pmu->max_period));
 		write_aux_reg(ARC_REG_PCT_INT_CNTH,
 			      upper_32_bits(arc_pmu->max_period));
+#endif
 	}
 
 	write_aux_reg(ARC_REG_PCT_CONFIG, 0);


### PR DESCRIPTION
ARCv2's high registers (SNAPH/INT_CNTH/COUNTH) are not functional
in ARCv3 64-bit where we should use 64-bit low registers.

---

After this change:
```
# perf stat hackbench
Running in process mode with 10 groups using 40 file descriptors each (== 400 tasks)
Each sender will pass 100 messages of 100 bytes
random: crng init done
Time: 104.460

 Performance counter stats for 'hackbench':

         109475.72 msec task-clock                #    0.995 CPUs utilized
             86639      context-switches          #    0.791 K/sec
                 0      cpu-migrations            #    0.000 K/sec
             19740      page-faults               #    0.180 K/sec
        5465338812      cycles                    #    0.050 GHz
        1429495258      instructions              #    0.26  insn per cycle
         147361994      branches                  #    1.346 M/sec
          41339590      branch-misses             #   28.05% of all branches

     110.046078240 seconds time elapsed

       8.364946000 seconds user
     101.429644000 seconds sys


# cat /proc/interrupts
           CPU0
 16:      13503  ARCv2 core Intc  16  Timer0 (per-cpu-tick)
 20:          0  ARCv2 core Intc  20  ARC perf counters
 24:        285  ARCv2 core Intc  24  ttyS0
# perf record -e cycles -c 100000 hackbench
Couldn't synthesize bpf events.
Running in process mode with 10 groups using 40 file descriptors each (== 400 tasks)
Each sender will pass 100 messages of 100 bytes
Time: 124.189
[ perf record: Woken up 8 times to write data ]
[ perf record: Captured and wrote 1.891 MB perf.data (60740 samples) ]

# cat /proc/interrupts
           CPU0
 16:      27789  ARCv2 core Intc  16  Timer0 (per-cpu-tick)
 20:      60740  ARCv2 core Intc  20  ARC perf counters
 24:        548  ARCv2 core Intc  24  ttyS0
```