### PR TITLE
ARCv3: use "stop_pc_val" of correct size in ptrace

### DIFF
--- a/arch/arc/kernel/ptrace.c
+++ b/arch/arc/kernel/ptrace.c
@@ -25,7 +25,7 @@ static int genregs_get(struct task_struct *target,
 	const struct pt_regs *ptregs = task_pt_regs(target);
 	const struct callee_regs *cregs = task_callee_regs(target);
 	int ret = 0;
-	unsigned int stop_pc_val;
+	unsigned long stop_pc_val;
 
 #define REG_O_CHUNK(START, END, PTR)	\
 	if (!ret)	\


### PR DESCRIPTION
"stop_pc_val" variable defined in "gen_regsget()" is a
4-byte variable. This goes awry when it is used for
transferring the PC value for ARCv3 which is 8 bytes long.

Signed-off-by: Shahab Vahedi <shahab@synopsys.com>