### PR TITLE
ARCv3: mm: Better way to setup kernel mappings in per-task page table

### DIFF
--- a/arch/arc/include/asm/mmu_context.h
+++ b/arch/arc/include/asm/mmu_context.h
@@ -149,7 +149,6 @@ static inline void switch_mm(struct mm_struct *prev, struct mm_struct *next,
 	mmu_setup_pgd(next, next->pgd);
 }
 
-#ifndef CONFIG_ARC_MMU_V6
 /*
  * Called at the time of execve() to get a new ASID
  * Note the subtlety here: get_new_mmu_context() behaves differently here
@@ -158,9 +157,6 @@ static inline void switch_mm(struct mm_struct *prev, struct mm_struct *next,
  * only if it was unallocated
  */
 #define activate_mm(prev, next)		switch_mm(prev, next, NULL)
-#else
-extern void activate_mm(struct mm_struct *prev, struct mm_struct *next);
-#endif
 
 /* it seemed that deactivate_mm( ) is a reasonable place to do book-keeping
  * for retiring-mm. However destroy_context( ) still needs to do that because
@@ -175,19 +171,17 @@ extern void activate_mm(struct mm_struct *prev, struct mm_struct *next);
 
 /* override mm_hooks.h */
 
-#ifndef CONFIG_ARC_MMU_V6
 static inline int arch_dup_mmap(struct mm_struct *oldmm,
 				struct mm_struct *mm)
 {
 	return 0;
 }
 
+#ifndef CONFIG_ARC_MMU_V6
 static inline void arch_exit_mmap(struct mm_struct *mm)
 {
 }
-
 #else
-extern int arch_dup_mmap(struct mm_struct *oldmm, struct mm_struct *mm);
 extern void arch_exit_mmap(struct mm_struct *mm);
 #endif
 

--- a/arch/arc/mm/tlb-arcv3.c
+++ b/arch/arc/mm/tlb-arcv3.c
@@ -163,24 +163,6 @@ noinline void mmu_setup_asid(struct mm_struct *mm, unsigned long asid)
 #endif
 }
 
-void activate_mm(struct mm_struct *prev_mm, struct mm_struct *next_mm)
-{
-	int map = 0;
-
-	map = arc_map_kernel_in_mm(next_mm);
-	BUG_ON(map);
-
-	switch_mm(prev_mm, next_mm, NULL);
-}
-
-int arch_dup_mmap(struct mm_struct *oldmm, struct mm_struct *mm)
-{
-	int map = arc_map_kernel_in_mm(mm);
-	BUG_ON(map);
-
-	return 0;
-}
-
 void arch_exit_mmap(struct mm_struct *mm)
 {
 	/*


### PR DESCRIPTION
In the current RTP0 only mapping regime, kernel translations are also
setup via RTP0 (which canonically is used for user mappings)

 - early boot code sets RTP0 directly with kernel swapper_pg_dir / swapper_pud

 - when userspace starts, RTP0 has user PGD -> PUD, but kernel identity
   mapppings are copied into user PUD at right location via
   arc_map_kernel_in_mm().

So far this was done on demand:
 - activate_mm()   -> execve
 - arch_dup_mmap() -> fork

However a better way to do this is to copy the kernel entries into user pud
right when user pud is allocated (like some other arches). This avoids the
need for the additional arch 2 hooks to do on-demand copy. This patch thus
removes them.

**The only caveat is, when you swtich to linking kernel in RTP1, the copying needs to happen on user PGD (not PUD) for the last pgd index.** But that would have required changing arc_map_kernel_in_mm() in current regime too.

Signed-off-by: Vineet Gupta <vgupta@kernel.org>