### PR TITLE
[RFC]: ARC: atomics: enable kernel support for new ARCv3 in-place atomics

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -415,6 +415,12 @@ config ARC_HAS_LLSC
 	default y
 	depends on !ARC_CANT_LLSC
 
+config ARC_HAS_ATLD
+	bool "Insn: ATLD (efficient fetch-and-operate atomic ops)"
+	default n
+	depends on ISA_ARCV3
+	depends on ARC_HAS_LLSC
+
 config ARC_HAS_SWAPE
 	bool "Insn: SWAPE (endian-swap)"
 	default y

--- a/arch/arc/include/asm/atomic.h
+++ b/arch/arc/include/asm/atomic.h
@@ -21,7 +21,7 @@
 #define atomic_read(v)          READ_ONCE((v)->counter)
 #define atomic_set(v, i)        WRITE_ONCE(((v)->counter), (i))
 
-#define ATOMIC_OP(op, c_op, asm_op)					\
+#define ATOMIC_OP(op, asm_op)					\
 static inline void atomic_##op(int i, atomic_t *v)			\
 {									\
 	unsigned int val;						\
@@ -37,7 +37,7 @@ static inline void atomic_##op(int i, atomic_t *v)			\
 	: "cc");							\
 }									\
 
-#define ATOMIC_OP_RETURN(op, c_op, asm_op)				\
+#define ATOMIC_OP_RETURN(op, asm_op)				\
 static inline int atomic_##op##_return_relaxed(int i, atomic_t *v)	\
 {									\
 	unsigned int val;						\
@@ -58,7 +58,7 @@ static inline int atomic_##op##_return_relaxed(int i, atomic_t *v)	\
 #define atomic_add_return_relaxed	atomic_add_return_relaxed
 #define atomic_sub_return_relaxed	atomic_sub_return_relaxed
 
-#define ATOMIC_FETCH_OP(op, c_op, asm_op)				\
+#define ATOMIC_FETCH_OP(op, asm_op)				\
 static inline int atomic_fetch_##op##_relaxed(int i, atomic_t *v)		\
 {									\
 	unsigned int val, orig;						\
@@ -85,25 +85,25 @@ static inline int atomic_fetch_##op##_relaxed(int i, atomic_t *v)		\
 #define atomic_fetch_or_relaxed		atomic_fetch_or_relaxed
 #define atomic_fetch_xor_relaxed	atomic_fetch_xor_relaxed
 
-#define ATOMIC_OPS(op, c_op, asm_op)					\
-	ATOMIC_OP(op, c_op, asm_op)					\
-	ATOMIC_OP_RETURN(op, c_op, asm_op)				\
-	ATOMIC_FETCH_OP(op, c_op, asm_op)
+#define ATOMIC_OPS(op, asm_op)					\
+	ATOMIC_OP(op, asm_op)					\
+	ATOMIC_OP_RETURN(op, asm_op)				\
+	ATOMIC_FETCH_OP(op, asm_op)
 
-ATOMIC_OPS(add, +=, add)
-ATOMIC_OPS(sub, -=, sub)
+ATOMIC_OPS(add, add)
+ATOMIC_OPS(sub, sub)
 
 #define atomic_andnot		atomic_andnot
 
 #undef ATOMIC_OPS
-#define ATOMIC_OPS(op, c_op, asm_op)					\
-	ATOMIC_OP(op, c_op, asm_op)					\
-	ATOMIC_FETCH_OP(op, c_op, asm_op)
+#define ATOMIC_OPS(op, asm_op)					\
+	ATOMIC_OP(op, asm_op)					\
+	ATOMIC_FETCH_OP(op, asm_op)
 
-ATOMIC_OPS(and, &=, and)
-ATOMIC_OPS(andnot, &= ~, bic)
-ATOMIC_OPS(or, |=, or)
-ATOMIC_OPS(xor, ^=, xor)
+ATOMIC_OPS(and, and)
+ATOMIC_OPS(andnot, bic)
+ATOMIC_OPS(or, or)
+ATOMIC_OPS(xor, xor)
 
 #elif defined(CONFIG_ARC_PLAT_EZNPS)
 

--- a/arch/arc/include/asm/atomic64-arcv2.h
+++ b/arch/arc/include/asm/atomic64-arcv2.h
@@ -118,7 +118,6 @@ static inline s64 atomic64_fetch_##op##_relaxed(s64 a, atomic64_t *v)	\
 	ATOMIC64_FETCH_OP(op, op1, op2)
 
 #define atomic64_andnot		atomic64_andnot
-#define atomic64_fetch_andnot	atomic64_fetch_andnot
 
 ATOMIC64_OPS(add, add.f, adc)
 ATOMIC64_OPS(sub, sub.f, sbc)

--- a/arch/arc/include/asm/atomic64-arcv2.h
+++ b/arch/arc/include/asm/atomic64-arcv2.h
@@ -63,7 +63,7 @@ static inline void atomic64_##op(s64 a, atomic64_t *v)			\
 	: "cc");							\
 }									\
 
-#define ATOMIC64_OP_RETURN(op, op1, op2)		        	\
+#define ATOMIC64_OP_RETURN(op, op1, op2)				\
 static inline s64 atomic64_##op##_return_relaxed(s64 a, atomic64_t *v)	\
 {									\
 	s64 val;							\
@@ -85,7 +85,7 @@ static inline s64 atomic64_##op##_return_relaxed(s64 a, atomic64_t *v)	\
 #define atomic64_add_return_relaxed	atomic64_add_return_relaxed
 #define atomic64_sub_return_relaxed	atomic64_sub_return_relaxed
 
-#define ATOMIC64_FETCH_OP(op, op1, op2)		        		\
+#define ATOMIC64_FETCH_OP(op, op1, op2)					\
 static inline s64 atomic64_fetch_##op##_relaxed(s64 a, atomic64_t *v)	\
 {									\
 	s64 val, orig;							\

--- a/arch/arc/include/asm/atomic64-arcv3.h
+++ b/arch/arc/include/asm/atomic64-arcv3.h
@@ -31,7 +31,7 @@ static inline void atomic64_##op(s64 a, atomic64_t *v)			\
 	: "cc");							\
 }									\
 
-#define ATOMIC64_OP_RETURN(op, op1)		        	\
+#define ATOMIC64_OP_RETURN(op, op1)					\
 static inline s64 atomic64_##op##_return_relaxed(s64 a, atomic64_t *v)	\
 {									\
 	s64 val;							\
@@ -49,7 +49,7 @@ static inline s64 atomic64_##op##_return_relaxed(s64 a, atomic64_t *v)	\
 	return val;							\
 }
 
-#define ATOMIC64_FETCH_OP(op, op1)		        		\
+#define ATOMIC64_FETCH_OP(op, op1)					\
 static inline s64 atomic64_fetch_##op##_relaxed(s64 a, atomic64_t *v)	\
 {									\
 	s64 val, orig;							\

--- a/arch/arc/include/asm/atomic64-arcv3.h
+++ b/arch/arc/include/asm/atomic64-arcv3.h
@@ -67,23 +67,37 @@ static inline s64 atomic64_fetch_##op##_relaxed(s64 a, atomic64_t *v)	\
 	return orig;							\
 }
 
+#ifdef CONFIG_ARC_HAS_ATLD
+#define ATOMIC64_FETCH_ATLD_OP(op, asm_op)				\
+static inline s64							\
+	atomic64_fetch_atldl_##op##_relaxed(s64 i, atomic64_t *v)	\
+{									\
+	s64 orig = i;							\
+									\
+	__asm__ __volatile__(						\
+	"	atldl."#asm_op" %0, %1 \n"				\
+	: "+r"(orig), "+ATOMC" (v->counter)				\
+	: 								\
+	: "memory");							\
+									\
+	return orig;							\
+}
+#endif
+
 #define ATOMIC64_OPS(op, op1)					\
 	ATOMIC64_OP(op, op1)					\
-	ATOMIC64_OP_RETURN(op, op1)				\
-	ATOMIC64_FETCH_OP(op, op1)
+	ATOMIC64_OP_RETURN(op, op1)
 
 ATOMIC64_OPS(add, addl)
 ATOMIC64_OPS(sub, subl)
 
-#define atomic64_fetch_add_relaxed	atomic64_fetch_add_relaxed
 #define atomic64_fetch_sub_relaxed	atomic64_fetch_sub_relaxed
 #define atomic64_add_return_relaxed	atomic64_add_return_relaxed
 #define atomic64_sub_return_relaxed	atomic64_sub_return_relaxed
 
 #undef ATOMIC64_OPS
 #define ATOMIC64_OPS(op, op1)					\
-	ATOMIC64_OP(op, op1)					\
-	ATOMIC64_FETCH_OP(op, op1)
+	ATOMIC64_OP(op, op1)
 
 ATOMIC64_OPS(and, andl)
 ATOMIC64_OPS(andnot, bicl)
@@ -91,13 +105,41 @@ ATOMIC64_OPS(or, orl)
 ATOMIC64_OPS(xor, xorl)
 
 #define atomic64_andnot			atomic64_andnot
-#define atomic64_fetch_and_relaxed	atomic64_fetch_and_relaxed
 #define atomic64_fetch_andnot_relaxed	atomic64_fetch_andnot_relaxed
+
+#ifdef CONFIG_ARC_HAS_ATLD
+
+#define atomic64_fetch_add_relaxed	atomic64_fetch_atldl_add_relaxed
+#define atomic64_fetch_and_relaxed	atomic64_fetch_atldl_and_relaxed
+#define atomic64_fetch_or_relaxed	atomic64_fetch_atldl_or_relaxed
+#define atomic64_fetch_xor_relaxed	atomic64_fetch_atldl_xor_relaxed
+
+	ATOMIC64_FETCH_ATLD_OP(add, add)
+	ATOMIC64_FETCH_ATLD_OP(and, and)
+	ATOMIC64_FETCH_ATLD_OP(xor, xor)
+	ATOMIC64_FETCH_ATLD_OP(or, or)
+
+	ATOMIC64_FETCH_OP(sub, subl)
+	ATOMIC64_FETCH_OP(andnot, bicl)
+#else
+
+#define atomic64_fetch_add_relaxed	atomic64_fetch_add_relaxed
+#define atomic64_fetch_and_relaxed	atomic64_fetch_and_relaxed
 #define atomic64_fetch_or_relaxed	atomic64_fetch_or_relaxed
 #define atomic64_fetch_xor_relaxed	atomic64_fetch_xor_relaxed
 
+	ATOMIC64_FETCH_OP(add, addl)
+	ATOMIC64_FETCH_OP(and, andl)
+	ATOMIC64_FETCH_OP(xor, xorl)
+	ATOMIC64_FETCH_OP(or, orl)
+
+	ATOMIC64_FETCH_OP(sub, subl)
+	ATOMIC64_FETCH_OP(andnot, bicl)
+#endif
+
 #undef ATOMIC64_OPS
 #undef ATOMIC64_FETCH_OP
+#undef ATOMIC64_FETCH_ATLD_OP
 #undef ATOMIC64_OP_RETURN
 #undef ATOMIC64_OP
 

--- a/arch/arc/include/asm/atomic64-arcv3.h
+++ b/arch/arc/include/asm/atomic64-arcv3.h
@@ -27,7 +27,7 @@ static inline void atomic64_##op(s64 a, atomic64_t *v)			\
 	"	scondl   %0, [%1]	\n"				\
 	"	bnz      1b		\n"				\
 	: "=&r"(val)							\
-	: "r"(&v->counter), "ir"(a)					\
+	: "r"(&v->counter), "r"(a)					\
 	: "cc");							\
 }									\
 
@@ -43,7 +43,7 @@ static inline s64 atomic64_##op##_return_relaxed(s64 a, atomic64_t *v)	\
 	"	scondl   %0, [%1]	\n"				\
 	"	bnz      1b		\n"				\
 	: [val] "=&r"(val)						\
-	: "r"(&v->counter), "ir"(a)					\
+	: "r"(&v->counter), "r"(a)					\
 	: "cc");	/* memory clobber comes from smp_mb() */	\
 									\
 	return val;							\
@@ -61,7 +61,7 @@ static inline s64 atomic64_fetch_##op##_relaxed(s64 a, atomic64_t *v)	\
 	"	scondl   %1, [%2]	\n"				\
 	"	bnz      1b		\n"				\
 	: "=&r"(orig), "=&r"(val)					\
-	: "r"(&v->counter), "ir"(a)					\
+	: "r"(&v->counter), "r"(a)					\
 	: "cc");	/* memory clobber comes from smp_mb() */	\
 									\
 	return orig;							\
@@ -115,7 +115,7 @@ atomic64_cmpxchg(atomic64_t *ptr, s64 expected, s64 new)
 	"	bnz     1b		\n"
 	"2:				\n"
 	: "=&r"(prev)
-	: "r"(ptr), "ir"(expected), "r"(new)
+	: "r"(ptr), "r"(expected), "r"(new)
 	: "cc");	/* memory clobber comes from smp_mb() */
 
 	smp_mb();


### PR DESCRIPTION
This PR provides the following major changes:

* Avoid unwanted GCC optimizations  in ARCv2/3 32/64bit atomics based on llock/scond
    All the llock/scond based atomic operations read and write atomic counter field. However write operation performed by the scond instruction is not properly communicated to the compiler: inline assembly shows atomic argument as an input parameter and clobber argument is not 'memory'. As a result, compiler can optimize the usage of atomic argument. This issue can be observed with the following simple test functions:
```c
    static void test_atomic_simple(void)
    {
            int v0 = 0xfaceabab;
            atomic_t v;
            int r;

            atomic_set(&v, v0);
            r = v0;

            atomic_inc(&v);
            r += 1;
            BUG_ON(v.counter != r);
    }

    static void test_atomic_simple64(void)
    {
            long long v0 = 0xfaceabadf00df001LL;
            atomic64_t v;
            long long r;

            atomic64_set(&v, v0);
            r = v0;

            atomic64_inc(&v);
            r += 1LL;
            BUG_ON(v.counter != r);
    }
```

* Fix immediate operand usage in ARCv3 64bit atomics
  ARCv3 ISA allows up to 32bit immediate operands. So passing 64bit argument as immediate operand effectively clears the upper 32bit word. Fix current 64bit atomic implementation by handle a 64bit argument as a register operand.

* Implement kernel support for new 'fetch-and-operate' ARCv3 atomics
  ARCv3 ISA provides ATLD family of instructions to support 'fetch-and-operate' atomic functions. Implement 'fetch-and-operate' kernel atomic functions using new instructions. Put new atomics under Kconfig option ARC_HAS_ATLD and disable it by default.

UPD:
Optimization issue is observed on HSDK with upstream 5.15 kernel. Appropriately adapted fix from this MR resolves the problem as well. 