### PR TITLE
ARC: module: add support for arc64

### DIFF
--- a/arch/arc/Makefile
+++ b/arch/arc/Makefile
@@ -91,9 +91,11 @@ ldflags-$(CONFIG_CPU_BIG_ENDIAN)	+= -EB
 
 LIBGCC	= $(shell $(CC) $(cflags-y) --print-libgcc-file-name)
 
-ifndef CONFIG_ISA_ARCV3
 # Modules with short calls might break for calls into builtin-kernel
+ifndef CONFIG_ISA_ARCV3
 KBUILD_CFLAGS_MODULE	+= -mlong-calls -mno-millicode
+else
+KBUILD_CFLAGS_MODULE	+= -mcmodel=large
 endif
 
 # Finally dump eveything into kernel build system

--- a/arch/arc/include/asm/elf.h
+++ b/arch/arc/include/asm/elf.h
@@ -47,8 +47,11 @@ int elf_check_arch(const struct elf32_hdr *x);
 
 /* ARC Relocations (kernel Modules only) */
 #define  R_ARC_32		0x4
+#define  R_ARC_64		0x5
 #define  R_ARC_32_ME		0x1B
 #define  R_ARC_32_PCREL		0x31
+#define  R_ARC_LO32_ME		0x5c
+#define  R_ARC_HI32_ME		0x5d
 
 #define CORE_DUMP_USE_REGSET
 

--- a/arch/arc/kernel/module.c
+++ b/arch/arc/kernel/module.c
@@ -101,10 +101,16 @@ int apply_relocate_add(Elf_Shdr *sechdrs,
 
 		if (likely(R_ARC_32_ME == relo_type))	/* ME ( S + A ) */
 			arc_write_me((unsigned short *)location, relocation);
+		else if (R_ARC_LO32_ME == relo_type)	/* ME ( ( S + A ) & 0xffffffff ) */
+			arc_write_me((unsigned short *)location, relocation & 0xffffffff);
+		else if (R_ARC_HI32_ME == relo_type)	/* ME ( ( S + A ) >> 32 ) */
+			arc_write_me((unsigned short *)location, relocation >> 32);
 		else if (R_ARC_32 == relo_type)		/* ( S + A ) */
 			*((Elf_Addr *) location) = relocation;
 		else if (R_ARC_32_PCREL == relo_type)	/* ( S + A ) - PDATA ) */
 			*((Elf_Addr *) location) = relocation - location;
+		else if (R_ARC_64 == relo_type)		/* ( S + A ) */
+			*((Elf_Addr *) location) = relocation;
 		else
 			goto relo_err;
 


### PR DESCRIPTION
Add support for loading modules on arc64. For this purpose add handling of relocations specific to arc64. Select large code model when compiling kernel modules. This is required to make sure that compiler will not make any assumptions about addresses of code and data. Otherwise compiler may break 'long' calls to built-in kernel functions.

Signed-off-by: Sergey Matyukevich <sergey.matyukevich@synopsys.com>