### PR TITLE
ARCv3: fix uname -m reporting

### DIFF
--- a/arch/arc/Makefile
+++ b/arch/arc/Makefile
@@ -8,13 +8,16 @@ KBUILD_DEFCONFIG := haps_hs_smp_defconfig
 ifeq ($(CROSS_COMPILE),)
 ifdef CONFIG_ISA_ARCV3
 CROSS_COMPILE := $(call cc-cross-prefix, arc64-elf- arc64-linux-gnu- arc64-linux- arc64-unknown-linux-gnu-)
+else
+CROSS_COMPILE := $(call cc-cross-prefix, arc-elf32- arc-linux- arceb-linux-)
+endif
+endif
+
+ifdef CONFIG_ISA_ARCV3
 ifdef CONFIG_64BIT
 UTS_MACHINE	:= arc64
 else
 UTS_MACHINE	:= arc32
-endif
-else
-CROSS_COMPILE := $(call cc-cross-prefix, arc-elf32- arc-linux- arceb-linux-)
 endif
 endif
 


### PR DESCRIPTION
Once again fix 'uname -m' reporting. Set UTS_MACHINE unconditionally,
not only for empty CROSS_COMPILE.

Reported-by: Artem Panfilov <artemp@synopsys.com>
Signed-off-by: Sergey Matyukevich <sergey.matyukevich@synopsys.com>