### PR TITLE
ARC: Fix phy address in copy_to_user_page()

### DIFF
--- a/arch/arc/include/asm/cacheflush.h
+++ b/arch/arc/include/asm/cacheflush.h
@@ -118,7 +118,8 @@ static inline int cache_is_vipt_aliasing(void)
 do {									\
 	memcpy(dst, src, len);						\
 	if (vma->vm_flags & VM_EXEC)					\
-		__sync_icache_dcache(dst, vaddr, len);	                \
+		__sync_icache_dcache(page_to_phys(page) + 		\
+				     (vaddr & ~PAGE_MASK), vaddr, len);	\
 } while (0)
 
 #define copy_from_user_page(vma, page, vaddr, dst, src, len)		\


### PR DESCRIPTION
ARC's __sync_icache_dcache requires phy address as a first
argument, but got virtual. We can't just use __pa here, because
it works only for direct-mapped kernel addresses but address
provided can be from anywhere. So use page_to_phys + offset to
calculate phys address from page structure and virtual address.

Signed-off-by: Vladimir Isaev <isaev@synopsys.com>