### PR TITLE
U-boot arguments fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,26 +18,29 @@ jobs:
     strategy:
       matrix:
         targets:
+          - cpu: arc700
+            toolchain: arc-elf
+            defconfig: nsim_700_defconfig
           - cpu: hs4x
-            toolchain: arc
+            toolchain: arc-glibc
             defconfig: haps_hs_defconfig
           - cpu: hs4x-pae40
-            toolchain: arc
+            toolchain: arc-glibc
             defconfig: haps_hs_defconfig
           - cpu: hs5x
-            toolchain: arc32
+            toolchain: arc32-glibc
             defconfig: haps_hs5x_defconfig
           - cpu: hs6x
-            toolchain: arc64
+            toolchain: arc64-glibc
             defconfig: haps_arc64_defconfig
           - cpu: hs6x-mmu48-16k
-            toolchain: arc64
+            toolchain: arc64-glibc
             defconfig: haps_arc64_defconfig
           - cpu: hs6x-mmu48-64k
-            toolchain: arc64
+            toolchain: arc64-glibc
             defconfig: haps_arc64_defconfig
           - cpu: hs6x-mmu52
-            toolchain: arc64
+            toolchain: arc64-glibc
             defconfig: haps_arc64_defconfig
       fail-fast: false
 
@@ -71,19 +74,32 @@ jobs:
         run: |
           echo "Toolchain version:" ${{ env.toolchain_ver }}
           echo "Toolchain base URL:" ${{ env.toolchain_url }}
-          curl -L -o toolchain.tar.gz ${{ env.toolchain_url }}/${{ matrix.targets.toolchain }}-glibc-${{ env.toolchain_ver }}.tar.gz
+          curl -L -o toolchain.tar.gz ${{ env.toolchain_url }}/${{ matrix.targets.toolchain }}-${{ env.toolchain_ver }}.tar.gz
           mkdir -p ${{ github.workspace }}/toolchain
           tar -xzf toolchain.tar.gz --strip 1 -C ${{ github.workspace }}/toolchain
 
       - name: Build linux kernel for ${{ matrix.targets.cpu }}
         run: |
+          toolchain_prefix="${{ matrix.targets.toolchain }}"
+          case "$toolchain_prefix" in
+          arc-elf)
+            toolchain_prefix="${toolchain_prefix/elf/elf32}"
+            ;;
+          *glibc)
+            toolchain_prefix="${toolchain_prefix/glibc/linux-gnu}"
+            ;;
+          esac
+
           export ARCH=arc
-          export CROSS_COMPILE=${{ github.workspace }}/toolchain/bin/${{ matrix.targets.toolchain }}-linux-gnu-
+          export CROSS_COMPILE="${{ github.workspace }}/toolchain/bin/${toolchain_prefix}-"
 
           make ${{ matrix.targets.defconfig }}
 
           # Select rootfs
           case "${{ matrix.targets.cpu }}" in
+          arc700*)
+            rootfs_path="${{ github.workspace }}/arc-kernel-ci/cpio/rootfs.cpio.arc700"
+            ;;
           hs4x*)
             rootfs_path="${{ github.workspace }}/arc-kernel-ci/cpio/rootfs.cpio.hs4x"
             ;;
@@ -145,7 +161,7 @@ jobs:
     runs-on: nsim
     strategy:
       matrix:
-        targets: [hs4x, hs4x-pae40, hs5x, hs6x, hs6x-mmu48-16k, hs6x-mmu48-64k, hs6x-mmu52]
+        targets: [arc700, hs4x, hs4x-pae40, hs5x, hs6x, hs6x-mmu48-16k, hs6x-mmu48-64k, hs6x-mmu52]
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
           - cpu: hs6x
             toolchain: arc64
             defconfig: haps_arc64_defconfig
+          - cpu: hs6x-mmu48-16k
+            toolchain: arc64
+            defconfig: haps_arc64_defconfig
+          - cpu: hs6x-mmu48-64k
+            toolchain: arc64
+            defconfig: haps_arc64_defconfig
+          - cpu: hs6x-mmu52
+            toolchain: arc64
+            defconfig: haps_arc64_defconfig
       fail-fast: false
 
     steps:
@@ -73,6 +82,7 @@ jobs:
 
           make ${{ matrix.targets.defconfig }}
 
+          # Select rootfs
           case "${{ matrix.targets.cpu }}" in
           hs4x*)
             rootfs_path="${{ github.workspace }}/arc-kernel-ci/cpio/rootfs.cpio.hs4x"
@@ -88,14 +98,30 @@ jobs:
             exit 1
             ;;
           esac
-
           ./scripts/config --set-str CONFIG_INITRAMFS_SOURCE "$rootfs_path"
 
-          if [[ "${{ matrix.targets.cpu }}" == "hs4x-pae40" ]]; then
+          # Other options if needed
+          case "${{ matrix.targets.cpu }}" in
+          hs4x-pae40)
             ./scripts/config --enable CONFIG_ARC_HAS_PAE40
-          fi
+            ;;
+          hs6x-mmu48-16k)
+            ./scripts/config --disable ARC_PAGE_SIZE_4K
+            ./scripts/config --enable ARC_PAGE_SIZE_16K
+            ;;
+          hs6x-mmu48-64k)
+            ./scripts/config --disable ARC_PAGE_SIZE_4K
+            ./scripts/config --enable ARC_PAGE_SIZE_64K
+            ;;
+          hs6x-mmu52)
+            ./scripts/config --disable ARC_MMU_V6_48
+            ./scripts/config --disable ARC_PAGE_SIZE_4K
+            ./scripts/config --enable ARC_MMU_V6_52
+            ./scripts/config --enable ARC_PAGE_SIZE_64K
+            ;;
+          esac
 
-          if [[ "${{ matrix.targets.cpu }}" =~ ^(hs5x|hs6x)$ ]]; then
+          if [[ "${{ matrix.targets.cpu }}" =~ ^(hs5x|hs6x) ]]; then
             image_name="loader"
             image_path=${{ github.workspace }}/arch/arc/boot/loader
           else
@@ -119,7 +145,7 @@ jobs:
     runs-on: nsim
     strategy:
       matrix:
-        targets: [hs4x, hs4x-pae40, hs5x, hs6x]
+        targets: [hs4x, hs4x-pae40, hs5x, hs6x, hs6x-mmu48-16k, hs6x-mmu48-64k, hs6x-mmu52]
       fail-fast: false
 
     steps:

--- a/arch/arc/include/asm/processor.h
+++ b/arch/arc/include/asm/processor.h
@@ -96,6 +96,12 @@ extern unsigned long __get_wchan(struct task_struct *p);
 #define VMALLOC_SIZE	(CONFIG_ARC_KVADDR_SIZE << 20)
 #define VMALLOC_END	(VMALLOC_START + VMALLOC_SIZE)
 
+/*
+ * How much memory to map before dtb parsing and paging init.
+ * 1Gb is selected to fit in one PUD for any ARCv3 MMU configurations.
+ */
+#define EARLY_MAP_SIZE	(1 << 30)
+
 #elif defined(CONFIG_ARC_MMU_V6_32)
 /*
  * Default System Memory Map on ARC
@@ -116,6 +122,12 @@ extern unsigned long __get_wchan(struct task_struct *p);
 #define VMALLOC_END	(VMALLOC_START + VMALLOC_SIZE)
 
 #define FIXADDR_START	(VMALLOC_START + VMALLOC_SIZE)
+
+/*
+ * How much memory to map before dtb parsing and paging init.
+ * 1Gb is selected to fit in one PUD for any ARCv3 MMU configurations.
+ */
+#define EARLY_MAP_SIZE	(1 << 30)
 
 #else
 

--- a/arch/arc/kernel/head.S
+++ b/arch/arc/kernel/head.S
@@ -212,8 +212,8 @@
 	MOVI    r3, PAGE_OFFSET
 	; phy_addr <- CONFIG_LINUX_LINK_BASE
 	MOVI	r4, CONFIG_LINUX_LINK_BASE
-	; link_end <- _end , see vmlinux.ld.S
-	MOVA	r5, _end
+	; link_end <- EARLY_MAP_SIZE , see processor.h
+	MOVI	r5, (PAGE_OFFSET + EARLY_MAP_SIZE)
 
 	; pgd <- __pa(tbl_pg_dir)
 	MOVA	r6, \tbl_pg_dir

--- a/arch/arc/kernel/setup.c
+++ b/arch/arc/kernel/setup.c
@@ -553,7 +553,7 @@ void __init handle_uboot_args(void)
 
 	/* see if U-boot passed an external Device Tree blob */
 	if (uboot_tag == UBOOT_TAG_DTB) {
-		machine_desc = setup_machine_fdt((void *)uboot_arg);
+		machine_desc = setup_machine_fdt(__va(uboot_arg));
 
 		/* external Device Tree blob is invalid - use embedded one */
 		use_embedded_dtb = !machine_desc;
@@ -577,7 +577,7 @@ ignore_uboot_args:
 	if (append_cmdline) {
 		/* Ensure a whitespace between the 2 cmdlines */
 		strlcat(boot_command_line, " ", COMMAND_LINE_SIZE);
-		strlcat(boot_command_line, uboot_arg, COMMAND_LINE_SIZE);
+		strlcat(boot_command_line, __va(uboot_arg), COMMAND_LINE_SIZE);
 	}
 }
 


### PR DESCRIPTION
Fixed memory access to uboot arguments since they are needed at very early stage when we have no information about memory map.