### PR TITLE
ARC: Make sure U-boot args are 32-bit

### DIFF
--- a/arch/arc/kernel/head.S
+++ b/arch/arc/kernel/head.S
@@ -493,11 +493,11 @@ ENTRY(stext)
 	;    r2 = pointer to uboot provided cmdline or external DTB in mem
 	; These are handled later in handle_uboot_args()
 	MOVA	r4, @uboot_tag
-	STR	r0, r4
+	st	r0, [r4]
 	MOVA	r4, @uboot_magic
-	STR	r1, r4
+	st	r1, [r4]
 	MOVA	r4, @uboot_arg
-	STR	r2, r4
+	st	r2, [r4]
 
 	; setup "current" tsk and optionally cache it in dedicated r25
 	MOVA	r9, @init_task

--- a/arch/arc/kernel/setup.c
+++ b/arch/arc/kernel/setup.c
@@ -37,8 +37,8 @@
 unsigned int intr_to_DE_cnt;
 
 /* Part of U-boot ABI: see head.S */
-int __initdata uboot_tag;
-int __initdata uboot_magic;
+u32 __initdata uboot_tag;
+u32 __initdata uboot_magic;
 char __initdata *uboot_arg;
 
 const struct machine_desc *machine_desc;
@@ -546,7 +546,7 @@ void __init handle_uboot_args(void)
 	}
 
 	if (uboot_tag != UBOOT_TAG_NONE &&
-            uboot_arg_invalid((unsigned long)uboot_arg)) {
+            uboot_arg_invalid((unsigned long)__va(uboot_arg))) {
 		pr_warn(IGNORE_ARGS "invalid uboot arg: '%px'\n", uboot_arg);
 		goto ignore_uboot_args;
 	}


### PR DESCRIPTION
'STR' for 64-bit ARC becomes 'stl' which is 64-bit instruction.
Use 'st' and explicitly mark U-boot arguments as 32-bit type.

Signed-off-by: Vladimir Isaev <isaev@synopsys.com>