### PR TITLE
ARC: Proper kernel mapping

### DIFF
--- a/arch/arc/include/asm/pgtable-bits-arcv3.h
+++ b/arch/arc/include/asm/pgtable-bits-arcv3.h
@@ -73,7 +73,8 @@
 /* TBD: kernel is RWX by default, split it to code/data */
 #define _PAGE_KERNEL	(_PAGE_TABLE        |			\
 			 /* writable */				\
-			 _PAGE_NOTEXEC_U    | 	/* exec k */	\
+			 _PAGE_NOTEXEC_U    |			\
+			 _PAGE_NOTEXEC_K    |			\
 			 /* AP kernel only  |      global */	\
 			 _PAGE_ACCESSED     |			\
 			 _PAGE_SHARED_INNER |			\
@@ -82,7 +83,12 @@
 #define PAGE_NONE	__pgprot(_PAGE_BASE)	/* TBD */
 #define PAGE_TABLE	__pgprot(_PAGE_TABLE)
 #define PAGE_KERNEL	__pgprot(_PAGE_KERNEL)
-#define PAGE_KERNEL_BLK	__pgprot(_PAGE_KERNEL & ~_PAGE_LINK)
+#define PAGE_KERNEL_RW	__pgprot(_PAGE_KERNEL)
+#define PAGE_KERNEL_RWX	__pgprot(_PAGE_KERNEL & ~_PAGE_NOTEXEC_K)
+
+#define PAGE_KERNEL_BLK		__pgprot(PAGE_KERNEL & ~_PAGE_LINK)
+#define PAGE_KERNEL_BLK_RW	__pgprot(PAGE_KERNEL_RW & ~_PAGE_LINK)
+#define PAGE_KERNEL_BLK_RWX	__pgprot(PAGE_KERNEL_RWX & ~_PAGE_LINK)
 
 #define PAGE_R		__pgprot(_PAGE_BASE)
 #define PAGE_RW		__pgprot(_PAGE_RW)

--- a/arch/arc/kernel/head.S
+++ b/arch/arc/kernel/head.S
@@ -91,13 +91,11 @@
 ;       All registers are clobbered.
 .macro BUILD_PAGE_TABLE, link_addr, phy_addr, link_end, pgd, pud, pmd, cur, tmp
 
-; FIXME: we need asserts about kernel size <= allocated size
-; FIXME: we need a better way to generalize this
 #if defined(CONFIG_ARC_MMU_V6_48) && defined(CONFIG_ARC_PAGE_SIZE_4K)
 
 ; Two-level page table, PGD + PUD
-#define BUILD_PGD_ENTRY BUILD_PAGE_TABLE_ENTRY \pgd, \link_addr, \pud, \cur, \tmp, PTRS_PER_PGD, PGDIR_SHIFT, PAGE_KERNEL
-#define BUILD_PUD_ENTRY BUILD_PAGE_TABLE_ENTRY \pud, \link_addr, \phy_addr, \cur, \tmp, PTRS_PER_PUD, PUD_SHIFT, PAGE_KERNEL_BLK
+#define BUILD_PGD_ENTRY BUILD_PAGE_TABLE_ENTRY \pgd, \link_addr, \pud, \cur, \tmp, PTRS_PER_PGD, PGDIR_SHIFT, PAGE_KERNEL_RWX
+#define BUILD_PUD_ENTRY BUILD_PAGE_TABLE_ENTRY \pud, \link_addr, \phy_addr, \cur, \tmp, PTRS_PER_PUD, PUD_SHIFT, PAGE_KERNEL_BLK_RWX
 #define BUILD_PMD_ENTRY
 #define ENTRY_SIZE	PUD_SIZE
 #define ENTRY_LABEL	.Lbuild_pud_entry\@
@@ -105,18 +103,18 @@
 #elif defined(CONFIG_ARC_MMU_V6_48) && defined(CONFIG_ARC_PAGE_SIZE_16K)
 
 ; Three-level page table, PGD + PUD + PMD
-#define BUILD_PGD_ENTRY BUILD_PAGE_TABLE_ENTRY \pgd, \link_addr, \pud, \cur, \tmp, PTRS_PER_PGD, PGDIR_SHIFT, PAGE_KERNEL
-#define BUILD_PUD_ENTRY BUILD_PAGE_TABLE_ENTRY \pud, \link_addr, \pmd, \cur, \tmp, PTRS_PER_PUD, PUD_SHIFT, PAGE_KERNEL
-#define BUILD_PMD_ENTRY BUILD_PAGE_TABLE_ENTRY \pmd, \link_addr, \phy_addr, \cur, \tmp, PTRS_PER_PMD, PMD_SHIFT, PAGE_KERNEL_BLK
+#define BUILD_PGD_ENTRY BUILD_PAGE_TABLE_ENTRY \pgd, \link_addr, \pud, \cur, \tmp, PTRS_PER_PGD, PGDIR_SHIFT, PAGE_KERNEL_RWX
+#define BUILD_PUD_ENTRY BUILD_PAGE_TABLE_ENTRY \pud, \link_addr, \pmd, \cur, \tmp, PTRS_PER_PUD, PUD_SHIFT, PAGE_KERNEL_RWX
+#define BUILD_PMD_ENTRY BUILD_PAGE_TABLE_ENTRY \pmd, \link_addr, \phy_addr, \cur, \tmp, PTRS_PER_PMD, PMD_SHIFT, PAGE_KERNEL_BLK_RWX
 #define ENTRY_SIZE	PMD_SIZE
 #define ENTRY_LABEL	.Lbuild_pmd_entry\@
 
 #elif defined(CONFIG_ARC_MMU_V6_48) && defined(CONFIG_ARC_PAGE_SIZE_64K) || defined(CONFIG_ARC_MMU_V6_52) || defined(CONFIG_ARC_MMU_V6_32)
 
 ; Two-level page table, PGD + PMD
-#define BUILD_PGD_ENTRY BUILD_PAGE_TABLE_ENTRY \pgd, \link_addr, \pmd, \cur, \tmp, PTRS_PER_PGD, PGDIR_SHIFT, PAGE_KERNEL
+#define BUILD_PGD_ENTRY BUILD_PAGE_TABLE_ENTRY \pgd, \link_addr, \pmd, \cur, \tmp, PTRS_PER_PGD, PGDIR_SHIFT, PAGE_KERNEL_RWX
 #define BUILD_PUD_ENTRY
-#define BUILD_PMD_ENTRY BUILD_PAGE_TABLE_ENTRY \pmd, \link_addr, \phy_addr, \cur, \tmp, PTRS_PER_PMD, PMD_SHIFT, PAGE_KERNEL_BLK
+#define BUILD_PMD_ENTRY BUILD_PAGE_TABLE_ENTRY \pmd, \link_addr, \phy_addr, \cur, \tmp, PTRS_PER_PMD, PMD_SHIFT, PAGE_KERNEL_BLK_RWX
 #define ENTRY_SIZE	PMD_SIZE
 #define ENTRY_LABEL	.Lbuild_pmd_entry\@
 

--- a/arch/arc/kernel/setup.c
+++ b/arch/arc/kernel/setup.c
@@ -499,8 +499,8 @@ void setup_processor(void)
 	arc_chk_core_config(&info);
 
 	arc_init_IRQ();
-	/* No ned to setup MMU for secondary CPU for ARCv3. */
-	if (!IS_ENABLED(CONFIG_ISA_ARCV3) || c == 0)
+	/* ARCv3 MMU must be initialized after setup_arch_memory. */
+	if (!IS_ENABLED(CONFIG_ISA_ARCV3))
 		arc_mmu_init();
 	arc_cache_init();
 }
@@ -603,6 +603,8 @@ void __init setup_arch(char **cmdline_p)
 
 	setup_processor();
 	setup_arch_memory();
+	if (IS_ENABLED(CONFIG_ISA_ARCV3))
+		arc_mmu_init();
 
 	/* copy flat DT out of .init and then unflatten it */
 	unflatten_and_copy_device_tree();

--- a/arch/arc/kernel/vmlinux.lds.S
+++ b/arch/arc/kernel/vmlinux.lds.S
@@ -56,14 +56,11 @@ SECTIONS
 	 *	decompress_inflate.c:gunzip( ) -> zlib_inflate_workspace( )
 	 */
 
+	. = ALIGN(PAGE_SIZE);
 	__init_begin = .;
+	__init_data_begin = .;
 
 	.init.ramfs : { INIT_RAM_FS }
-
-	. = ALIGN(PAGE_SIZE);
-
-	HEAD_TEXT_SECTION
-	INIT_TEXT_SECTION(L1_CACHE_BYTES)
 
 	/* INIT_DATA_SECTION open-coded: special INIT_RAM_FS handling */
 	.init.data : {
@@ -82,6 +79,14 @@ SECTIONS
 	PERCPU_SECTION(L1_CACHE_BYTES)
 
 	. = ALIGN(PAGE_SIZE);
+	__init_data_end = .;
+	__init_text_begin = .;
+
+	HEAD_TEXT_SECTION
+	INIT_TEXT_SECTION(L1_CACHE_BYTES)
+
+	. = ALIGN(PAGE_SIZE);
+	__init_text_end = .;
 	__init_end = .;
 
 	.text : {
@@ -98,6 +103,7 @@ SECTIONS
 		*(.gnu.warning)
 	}
 	EXCEPTION_TABLE(L1_CACHE_BYTES)
+	. = ALIGN(PAGE_SIZE);
 	_etext = .;
 
 	_sdata = .;


### PR DESCRIPTION
Use proper page flags for different memory sections,
for example X is used only for text section.

Previously we mapped kernel as an one big chunk.

Now kernel mapping is page-based, so it requires to have
memblock initialized to be able to allocate page entries
dynamically.

Signed-off-by: Vladimir Isaev <isaev@synopsys.com>