### PR TITLE
Revert: ARCv3: link above 4GB: handle 64-bit literals in final link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,6 @@ jobs:
           - cpu: hs5x-hw-atomic64
             toolchain: arc32-glibc
             defconfig: haps_hs5x_defconfig
-          - cpu: hs6x
-            toolchain: arc64-glibc
-            defconfig: haps_arc64_defconfig
-          - cpu: hs6x-mmu48-16k
-            toolchain: arc64-glibc
-            defconfig: haps_arc64_defconfig
-          - cpu: hs6x-mmu48-64k
-            toolchain: arc64-glibc
-            defconfig: haps_arc64_defconfig
-          - cpu: hs6x-mmu52
-            toolchain: arc64-glibc
-            defconfig: haps_arc64_defconfig
       fail-fast: false
 
     steps:
@@ -170,7 +158,7 @@ jobs:
     runs-on: nsim
     strategy:
       matrix:
-        targets: [arc700, hs4x, hs4x-pae40, hs5x, hs5x-hw-atomic64, hs6x, hs6x-mmu48-16k, hs6x-mmu48-64k, hs6x-mmu52]
+        targets: [arc700, hs4x, hs4x-pae40, hs5x, hs5x-hw-atomic64]
       fail-fast: false
 
     steps:

--- a/arch/arc/include/asm/entry.h
+++ b/arch/arc/include/asm/entry.h
@@ -129,13 +129,11 @@
 #else   /* Uniprocessor implementation of macros */
 
 .macro  GET_CURR_TASK_ON_CPU    reg
-	MOVA \reg, @_current_task
-	LDR  \reg, \reg
+	LDR  \reg, @_current_task
 .endm
 
 .macro  SET_CURR_TASK_ON_CPU    tsk, tmp
-	MOVA \tmp, @_current_task
-	STR  \tsk, \tmp
+	STR  \tsk, @_current_task
 #ifdef CONFIG_ARC_CURR_IN_REG
 	MOVR gp, \tsk
 #endif

--- a/arch/arc/include/asm/futex.h
+++ b/arch/arc/include/asm/futex.h
@@ -30,7 +30,7 @@
 	"	.section .fixup,\"ax\"		\n"	\
 	"	.align  4			\n"	\
 	"4:	mov %0, %4			\n"	\
-	"	b   3b				\n"	\
+	"	j   3b				\n"	\
 	"	.previous			\n"	\
 	"	.section __ex_table,\"a\"	\n"	\
 	"	.align  " REGSZASM  "		\n"	\
@@ -57,7 +57,7 @@
 	"	.section .fixup,\"ax\"		\n"	\
 	"	.align  4			\n"	\
 	"4:	mov %0, %4			\n"	\
-	"	b   3b				\n"	\
+	"	j   3b				\n"	\
 	"	.previous			\n"	\
 	"	.section __ex_table,\"a\"	\n"	\
 	"	.align  " REGSZASM  "		\n"	\
@@ -148,7 +148,7 @@ futex_atomic_cmpxchg_inatomic(u32 *uval, u32 __user *uaddr, u32 expval,
 	"3:	\n"
 	"	.section .fixup,\"ax\"	\n"
 	"4:	mov %0, %5	\n"
-	"	b   3b	\n"
+	"	j   3b	\n"
 	"	.previous	\n"
 	"	.section __ex_table,\"a\"	\n"
 	"	.align  " REGSZASM  "		\n"

--- a/arch/arc/include/asm/uaccess.h
+++ b/arch/arc/include/asm/uaccess.h
@@ -84,7 +84,7 @@
 	"	mov %0, %3\n"			\
 	"	# zero out dst ptr\n"		\
 	"	mov %1,  0\n"			\
-	"	b   2b\n"			\
+	"	j   2b\n"			\
 	"	.previous\n"			\
 	"	.section __ex_table, \"a\"\n"	\
 	"	.align  " REGSZASM "	\n"	\
@@ -118,7 +118,7 @@
 	"	# zero out dst ptr\n"		\
 	"	mov %1,  0\n"			\
 	"	mov %R1, 0\n"			\
-	"	b   2b\n"			\
+	"	j   2b\n"			\
 	"	.previous\n"			\
 	"	.section __ex_table, \"a\"\n"	\
 	"	.align 4\n"			\
@@ -150,7 +150,7 @@
 	"	.section .fixup, \"ax\"\n"	\
 	"	.align 4\n"			\
 	"3:	mov %0, %3\n"			\
-	"	b   2b\n"			\
+	"	j   2b\n"			\
 	"	.previous\n"			\
 	"	.section __ex_table, \"a\"\n"	\
 	"	.align  " REGSZASM "	\n"	\
@@ -180,7 +180,7 @@
 	"	.section .fixup, \"ax\"\n"	\
 	"	.align 4\n"			\
 	"3:	mov %0, %3\n"			\
-	"	b   2b\n"			\
+	"	j   2b\n"			\
 	"	.previous\n"			\
 	"	.section __ex_table, \"a\"\n"	\
 	"	.align 4\n"			\
@@ -221,7 +221,7 @@ raw_copy_from_user(void *to, const void __user *from, unsigned long n)
 		"2:	;nop				\n"
 		"	.section .fixup, \"ax\"		\n"
 		"	.align 4			\n"
-		"3:	b   2b				\n"
+		"3:	j   2b				\n"
 		"	.previous			\n"
 		"	.section __ex_table, \"a\"	\n"
 		"	.align 4			\n"

--- a/arch/arc/kernel/entry-cmn.S
+++ b/arch/arc/kernel/entry-cmn.S
@@ -96,8 +96,8 @@ ENTRY(EV_TLBProtV)
 
 	EXCEPTION_PROLOGUE
 
-	bl    do_page_fault
-	b    ret_from_exception
+	MOVR blink, ret_from_exception
+	b    do_page_fault
 
 END(EV_TLBProtV)
 
@@ -180,10 +180,9 @@ debug_marker_syscall:
 .Lintr_ret_to_delay_slot:
 debug_marker_ds:
 
-	MOVA	r3, @intr_to_DE_cnt
-	ld	r2, [r3]
+	ld	r2, [@intr_to_DE_cnt]
 	add	r2, r2, 1
-	st	r2, [r3]
+	st	r2, [@intr_to_DE_cnt]
 
 	; drop out of interrupt context (clear AUX_IRQ_ACT.active)
 	bmskn	r11, r10, 15

--- a/arch/arc/kernel/entry.S
+++ b/arch/arc/kernel/entry.S
@@ -51,7 +51,7 @@ ENTRY(ret_from_fork)
 	; when the forked child comes here from the __switch_to function
 	; r0 has the last task pointer.
 	; put last task in scheduler queue
-	bl   @schedule_tail
+	jl   @schedule_tail
 
 	ld   r9, [sp, PT_status32]
 	brne r9, 0, 1f
@@ -109,7 +109,7 @@ ENTRY(EV_MachineCheck)
 	GET_CURR_TASK_FIELD_PTR   TASK_THREAD, r10
 	st  sp, [r10, THREAD_CALLEE_REG]
 
-	b  do_machine_check_fault
+	j  do_machine_check_fault
 
 END(EV_MachineCheck)
 
@@ -269,8 +269,8 @@ resume_user_mode_begin:
 
 	; --- (Slow Path #1) task preemption ---
 	bbit0  r9, TIF_NEED_RESCHED, .Lchk_pend_signals
-	bl     @schedule 	; BTST+Bnz causes relo error in link
-	b      resume_user_mode_begin
+	MOVR   blink, resume_user_mode_begin  ; tail-call to U mode ret chks
+	j      @schedule 	; BTST+Bnz causes relo error in link
 
 .Lchk_pend_signals:
 	IRQ_ENABLE	r10
@@ -332,7 +332,7 @@ resume_kernel_mode:
 	bbit0  r9, TIF_NEED_RESCHED, .Lrestore_regs
 
 	; Invoke PREEMPTION
-	bl      preempt_schedule_irq
+	jl      preempt_schedule_irq
 
 	; preempt_schedule_irq() always returns with IRQ disabled
 #endif


### PR DESCRIPTION
This reverts commit 955b7c7007e9 ("ARCv3: link above 4GB: handle 64-bit literals in final link"). And with that change reverted we'll get rid of unexpected R_ARC_S25H_PCREL relocation on 32-bit ARC processors.

That will break Linux kernel for 64-bit processors for sure, but we're working on a proper fix for that issue, to that it gets fixed fundamentally.