### PR TITLE
Add R_ARC_S25H_PCREL relocation inti the kernel

### DIFF
--- a/arch/arc/include/asm/elf.h
+++ b/arch/arc/include/asm/elf.h
@@ -48,6 +48,7 @@ int elf_check_arch(const struct elf32_hdr *x);
 /* ARC Relocations (kernel Modules only) */
 #define  R_ARC_32		0x4
 #define  R_ARC_64		0x5
+#define  R_ARC_S25H_PCREL	0x10
 #define  R_ARC_32_ME		0x1B
 #define  R_ARC_32_PCREL		0x31
 #define  R_ARC_LO32_ME		0x5c

--- a/arch/arc/include/asm/uaccess.h
+++ b/arch/arc/include/asm/uaccess.h
@@ -109,7 +109,7 @@
 #define __arc_get_user_one_64(dst, src, ret)	\
 	__asm__ __volatile__(                   \
 	"1:	ld   %1,[%2]\n"			\
-	"4:	ld  %R1,[%2, 4]\n"		\
+	"4:	ld  %H1,[%2, 4]\n"		\
 	"2:	;nop\n"				\
 	"	.section .fixup, \"ax\"\n"	\
 	"	.align 4\n"			\
@@ -117,7 +117,7 @@
 	"	mov %0, %3\n"			\
 	"	# zero out dst ptr\n"		\
 	"	mov %1,  0\n"			\
-	"	mov %R1, 0\n"			\
+	"	mov %H1, 0\n"			\
 	"	b   2b\n"			\
 	"	.previous\n"			\
 	"	.section __ex_table, \"a\"\n"	\

--- a/arch/arc/lib/uaccess.S
+++ b/arch/arc/lib/uaccess.S
@@ -4,6 +4,7 @@
  *   ASSUMES unaligned access
  */
 
+#include <asm-generic/export.h>
 #include <linux/linkage.h>
 #include <asm/assembler.h>
 
@@ -124,6 +125,7 @@ ENTRY_CFI(__clear_user)
 	sub    r0, r8, r0
 
 END_CFI(__clear_user)
+EXPORT_SYMBOL(__clear_user)
 
 ; Note that .fixup section is missing and that is not an omission
 ;


### PR DESCRIPTION
Add the R_ARC_S25H_PCREL relocation to the list of known and add code to resolve this relocation.
Replacement of jump instructions (j) to branches (b) in the .fixup section (commit 955b7c7007e9) cause to appearance of the new relocation type R_ARC_S25H_PCREL, which can be added by the compiler to handle relative offsets in kernel modules.

Decision to use branch instructions in the .fixup section is not optimal it limits jumps to +16M/-16M, but currently this should by enough, typical ARC kernel .text segment is about 4-8Mb.

Tested on ARCv2 le(QEMU), ARCv2 be(nSim), ARCv3 HS5x(QEMU), ARCv3HS6x(QEMU).
