### PR TITLE
ARCv3: HS5x: set correct compiler option for the ARC_HAS_LL64 config param

### DIFF
--- a/arch/arc/Makefile
+++ b/arch/arc/Makefile
@@ -87,17 +87,23 @@ cflags-y				+= -mno-div-rem
 endif
 
 ifneq ($(filter y,$(CONFIG_ISA_ARCV2)  $(CONFIG_ISA_ARCV3)),)
-
 ifdef CONFIG_ARC_USE_UNALIGNED_MEM_ACCESS
 cflags-y				+= -munaligned-access
 else
 cflags-y				+= -mno-unaligned-access
 endif
+endif
 
+ifdef CONFIG_ISA_ARCV2
 ifndef CONFIG_ARC_HAS_LL64
 cflags-y				+= -mno-ll64
 endif
+endif
 
+ifdef CONFIG_ISA_ARCV3
+ifndef CONFIG_64BIT
+cflags-$(CONFIG_ARC_HAS_LL64)		+= -mll64
+endif
 endif
 
 cfi := $(call as-instr,.cfi_startproc\n.cfi_endproc,-DARC_DW2_UNWIND_AS_CFI)


### PR DESCRIPTION
Current scheme with -mcpu=hs5x and -mno-ll64 if CONFIG_ARC_HAS_LL64 not set is incorrect. We expect that option -mcpu=hs5x tells the compiler to use duals loads/stores by default, but actually it is not true. By default -mcpu=hs5x doesn't enable use of 64-bit dual loads/stores and to enable them we have to add -mll64 option. It is reverse logic to one used for ARCv2 (hs38).
So, add extra conditions to implement new scheme with -mcpu=hs5x and -mll64 (for ll64) for ARCv3 32-bit architecture configs.
This commit handles #104 issue.