### PR TITLE
ARCv3: Add inner shareability attribute for DC operations

### DIFF
--- a/arch/arc/include/asm/cache.h
+++ b/arch/arc/include/asm/cache.h
@@ -101,6 +101,8 @@ extern unsigned long perip_base, perip_end;
 #define DC_CTRL_FLUSH_STATUS	0x100
 #define DC_CTRL_RGN_OP_INV	0x200
 #define DC_CTRL_RGN_OP_MSK	0x200
+#define DC_CTRL_SH_ATTR_INNER	0x3000
+#define DC_CTRL_SH_ATTR_MASK	0x3000
 
 /*System-level cache (L2 cache) related Auxiliary registers */
 #define ARC_REG_SLC_CFG		0x901

--- a/arch/arc/mm/cache-arcv3.c
+++ b/arch/arc/mm/cache-arcv3.c
@@ -136,6 +136,11 @@ static inline void __dc_op_before(const int op)
 	if (op & OP_INV)
 		val |= DC_CTRL_RGN_OP_INV;
 
+	// Set shareability attribute for DC operation: Inner-shareable.
+	// The same as for a page shareability attributes: __SHR_INNER.
+	val &= ~DC_CTRL_SH_ATTR_MASK;
+	val |= DC_CTRL_SH_ATTR_INNER;
+
 	write_aux_reg(ctl, val);
 }
 


### PR DESCRIPTION
Cache operations must be specified with the same shareability attributes as for MMU. Since we setup inner shareable attribute for MMU TBC register, lets do it the same for D$ operations.