### PR TITLE
ARCv3: Changes for flexible link base

### DIFF
--- a/arch/arc/boot/dts/haps_hs5x_idu.dts
+++ b/arch/arc/boot/dts/haps_hs5x_idu.dts
@@ -12,7 +12,7 @@
 	compatible = "snps,zebu_hs";
 
 	memory {
-		reg = <0x00000000 0x60000000>;	/* 1.5 GB */
+		reg = <0x80000000 0x40000000>;	/* 1.0 Gb */
 	};
 
 	chosen {

--- a/arch/arc/boot/dts/skeleton_haps_idu.dtsi
+++ b/arch/arc/boot/dts/skeleton_haps_idu.dtsi
@@ -63,10 +63,10 @@
 			interrupts = <20>;
 		};
 
-		arcpct2: cluster_pmu {
-			compatible = "snps,arcv3-cluster-pmu";
-			#interrupt-cells = <1>;
-			interrupts = <23>;
-		};
+		//arcpct2: cluster_pmu {
+			//compatible = "snps,arcv3-cluster-pmu";
+			//#interrupt-cells = <1>;
+			//interrupts = <23>;
+		//};
 	};
 };

--- a/arch/arc/include/asm/page.h
+++ b/arch/arc/include/asm/page.h
@@ -36,7 +36,7 @@
 #elif defined(CONFIG_ARC_MMU_V6_52)
 #define PAGE_OFFSET	_AC(0xfff0000000000000, UL)
 #else
-#define PAGE_OFFSET	_AC(0x80000000, UL)	/* Kernel starts at 2G onwrds */
+#define PAGE_OFFSET	_AC(0x80500000, UL)	/* Kernel starts at 2G onwrds */
 #endif
 
 #define PAGE_MASK	(~(PAGE_SIZE-1))

--- a/arch/arc/kernel/devtree.c
+++ b/arch/arc/kernel/devtree.c
@@ -18,7 +18,7 @@
 static unsigned int __initdata arc_base_baud;
 
 //These two variables exist only for debugging perposes
-volatile unsigned int glb_clock_freq = 20000000;
+volatile unsigned int glb_clock_freq = 30000000;
 volatile unsigned int glb_uart_baud = 115200;
 
 unsigned int __init arc_early_base_baud(void)

--- a/arch/arc/mm/cluster.c
+++ b/arch/arc/mm/cluster.c
@@ -14,8 +14,8 @@ void arc_cluster_mumbojumbo()
 	 * SCM -> 0xFz+1MB -> 1Mb
 	 */
 
-	arc_cln_write_reg(ARC_CLN_MST_NOC_0_0_ADDR, 0x000); //0x800
-	arc_cln_write_reg(ARC_CLN_MST_NOC_0_0_SIZE, 0x800); //0x400
+	arc_cln_write_reg(ARC_CLN_MST_NOC_0_0_ADDR, 0x800);
+	arc_cln_write_reg(ARC_CLN_MST_NOC_0_0_SIZE, 0x400);
 
 	arc_cln_write_reg(ARC_CLN_PER_0_BASE, 0xf00);
 	arc_cln_write_reg(ARC_CLN_PER_0_SIZE,   0x1);


### PR DESCRIPTION
+ Memory mapping fix for ranges 0x80000000..0x80500000

Now it can be loaded on:
r38759606_2022-10-04/_HS58x3_Linux_12way
r39742414_2022-12-02/_HS58x3_Linux_12way_ddr8