### PR TITLE
ARCv3: setup cluster apertures linked to dts file

### DIFF
--- a/arch/arc/kernel/setup.c
+++ b/arch/arc/kernel/setup.c
@@ -31,6 +31,7 @@
 #include <asm/fixmap.h>
 #include <asm/dsp-impl.h>
 #include <soc/arc/mcip.h>
+#include <asm/cluster.h>
 
 #define FIX_PTR(x)  __asm__ __volatile__(";" : "+r"(x))
 
@@ -602,6 +603,7 @@ void __init setup_arch(char **cmdline_p)
 
 	smp_init_cpus();
 
+	arc_cluster_mumbojumbo();
 	setup_processor();
 	setup_arch_memory();
 	if (IS_ENABLED(CONFIG_ISA_ARCV3))

--- a/arch/arc/mm/cache-arcv3.c
+++ b/arch/arc/mm/cache-arcv3.c
@@ -28,8 +28,6 @@ static int read_decode_cache_bcr_arcv3(int c, char *buf, int len)
 	if (cbcr.ver_maj == 0)
 		return n;
 
-	arc_cluster_mumbojumbo();
-
 	READ_BCR(ARC_REG_CLNR_BCR_0, cln0);
 
 	if (cln0.has_scm) {

--- a/arch/arc/mm/cluster.c
+++ b/arch/arc/mm/cluster.c
@@ -3,9 +3,19 @@
 #include <linux/mm.h>
 
 #include <asm/cluster.h>
+#include <linux/memblock.h>
 
-void arc_cluster_mumbojumbo()
+void __init arc_cluster_mumbojumbo()
 {
+	struct bcr_clustv3_cfg cbcr;
+	u64 i;
+	phys_addr_t start, end;
+	u32 offs, size;
+
+	READ_BCR(ARC_REG_CLUSTER_BCR, cbcr);
+	if (cbcr.ver_maj == 0)
+		return;
+
 	/*
 	 * Region -> Base -> Size
 	 *
@@ -14,8 +24,15 @@ void arc_cluster_mumbojumbo()
 	 * SCM -> 0xFz+1MB -> 1Mb
 	 */
 
-	arc_cln_write_reg(ARC_CLN_MST_NOC_0_0_ADDR, 0x000); //0x800
-	arc_cln_write_reg(ARC_CLN_MST_NOC_0_0_SIZE, 0x800); //0x400
+	for_each_mem_range(i, &start, &end) {
+		if ((start <= CONFIG_LINUX_LINK_BASE) && (CONFIG_LINUX_LINK_BASE < end)) {
+			offs = (u64)start >> 20U;
+			size = ((u64)end - (u64)start) >> 20U;
+			arc_cln_write_reg(ARC_CLN_MST_NOC_0_0_ADDR, offs);
+			arc_cln_write_reg(ARC_CLN_MST_NOC_0_0_SIZE, size);
+			break;
+		}
+	}
 
 	arc_cln_write_reg(ARC_CLN_PER_0_BASE, 0xf00);
 	arc_cln_write_reg(ARC_CLN_PER_0_SIZE,   0x1);


### PR DESCRIPTION
Hard coded range for cluster aperture has changed to flexible tune. Ranges now are taken from dts file.