### PR TITLE
ARCv3: Add an option to switch on SmaRT.

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -675,6 +675,16 @@ config ARC_DW2_UNWIND
 	  If you don't debug the kernel, you can say N, but we may not be able
 	  to solve problems without frame unwind information
 
+config ARC_SMART_ENABLE
+	bool "Enable small real time trace (SmaRT)"
+	default n
+	help
+	  SmaRT is an optional on-chip debug hardware component that captures
+	  instruction trace history. SmaRT stores the address of the most recent
+	  non-sequential instructions executed. The MetaWare debugger reads the
+	  saved instruction trace information via the JTAG port when the processor
+	  is halted.
+
 config ARC_DBG_JUMP_LABEL
 	bool "Paranoid checks in Static Keys (jump labels) code"
 	depends on JUMP_LABEL

--- a/arch/arc/kernel/head.S
+++ b/arch/arc/kernel/head.S
@@ -329,6 +329,18 @@
 	sr	@_int_vec_base_lds, [AUX_INTR_VEC_BASE]
 #endif
 
+#ifdef CONFIG_ARC_SMART_ENABLE
+.equ SMART_BUILD,    0xFF
+.equ SMART_CONTROL,  0x700
+		lr      r5, [SMART_BUILD]
+		and     r5, r5, 0xff
+		breq    r5, 0, 1f		; SmaRT doesn't exist
+		lr      r5, [SMART_CONTROL]
+		or      r5, r5, 1		; enable SmaRT
+		sr      r5, [SMART_CONTROL]
+1:
+#endif
+
 #ifdef CONFIG_ARC_HWPF
         lr      r5, [ARC_REG_HW_PF_CTRL]
         or      r5, r5, 1


### PR DESCRIPTION
Small real time trace (SmaRT) is an optional on-chip debug hardware component that captures instructiontrace history.
SmaRT stores the address of the most recent non-sequential instructions executed.
The MetaWare debugger reads the saved instruction trace information via the JTAG port when the processor is halted.

ARC_SMART_ENABLE menuconfig parameter can be used to switch SmaRT on.