### PR TITLE
ARCv3: Passing the correct LDFLAGS to the linker when building loader

### DIFF
--- a/arch/arc/boot/Makefile
+++ b/arch/arc/boot/Makefile
@@ -47,4 +47,4 @@ $(obj)/uImage.lzma: $(obj)/vmlinux.bin.lzma FORCE
 $(obj)/loader.o: $(src)/loader.S $(obj)/vmlinux.bin
 
 $(obj)/loader: $(obj)/loader.o $(obj)/vmlinux.bin $(obj)/loader.lds FORCE
-	$(Q)$(LD)  --defsym=_entry_point_virt=$(LINUX_ENTRY_VIRT) -T $(obj)/loader.lds -o $@ $(obj)/loader.o
+	$(Q)$(LD) $(KBUILD_LDFLAGS) --defsym=_entry_point_virt=$(LINUX_ENTRY_VIRT) -T $(obj)/loader.lds -o $@ $(obj)/loader.o


### PR DESCRIPTION
ARCv3 loader for 32-bit ARC HS58 didn't link if arc64-elf toolchain was used. That happened because LD flags wasn't being passed to the loader link command.