### PR TITLE
ARCv3: fix count of valid pfns

### DIFF
--- a/arch/arc/mm/init.c
+++ b/arch/arc/mm/init.c
@@ -102,7 +102,7 @@ void __init setup_arch_memory(void)
 	setup_initial_init_mm(_text, _etext, _edata, _end);
 
 	/* first page of system - kernel .vector starts here */
-	min_low_pfn = virt_to_pfn(CONFIG_LINUX_RAM_BASE);
+	min_low_pfn = PFN_DOWN(low_mem_start);
 
 	/* Last usable page of low mem */
 	max_low_pfn = max_pfn = PFN_DOWN(low_mem_start + low_mem_sz);


### PR DESCRIPTION
Fix count of min_low_pfn. For configurations where CONFIG_LINUX_RAM_BASE is not equal to PAGE_OFFSET we should consider CONFIG_LINUX_RAM_BASE as physical address.

This patch fixes check of virt address by virt_addr_valid() macro and allow to determine correctly whether the address resides in the "direct mapping area" in the kernel.

Without this patch some unexpected kernel crashes can be observed, for example in __check_object_size() function when because of incorrect check of virt_addr_valid() macro, virt_to_page() macro can be called with virt address from VMALLOC area and return bad pointer to page struct.

This change is actual for ARCv3 not affect behavior of ARCv2.

This issue has been pointed by kselftests: net:reuseport_bpf,  net:gro.sh, net: netdevice.sh, net:run_afpackettests and many others were crashed in __check_object_size with the following symptoms:
```
Oops
BUG: sleeping function called from invalid context at kernel/fork.c:1131
in_atomic(): 1, irqs_disabled(): 0, non_block: 0, pid: 146, name: gro
preempt_count: ffffffff, expected: 0
RCU nest depth: 0, expected: 0
INFO: lockdep is turned off.
CPU: 0 PID: 146 Comm: gro Not tainted 5.16.0 #10

Stack Trace:
------------[ cut here ]------------
WARNING: CPU: 0 PID: 146 at kernel/irq/irqdesc.c:679 generic_handle_domain_irq+0x94/0x98
Modules linked in:
CPU: 0 PID: 146 Comm: gro Not tainted 5.16.0 #10

Stack Trace:
irq event stamp: 0
hardirqs last  enabled at (0): [<0000000000000000>] 0x0
hardirqs last disabled at (0): [<ffff000003b33b66>] copy_process+0x756/0x1f60
softirqs last  enabled at (0): [<ffff000003b33b66>] copy_process+0x756/0x1f60
softirqs last disabled at (0): [<0000000000000000>] 0x0
---[ end trace 8f82d73d6d1d3b27 ]---
Path: /usr/lib/kselftests/net/gro
CPU: 0 PID: 146 Comm: gro Tainted: G        W         5.16.0 #10
Invalid Read @ 0xffff00403f001208 by insn @ __check_object_size+0xac/0x1fc
ECR: 0x00050100 EFA: 0xffff00403f001208 ERET: 0xffff000003d456d8
STAT: 0x80080802 [IE K     ]   BTA: 0xffff000003d45682
 SP: 0xffff00000d5b9df0  FP: 0x00000001 BLK: __check_object_size+0x56/0x1fc
r00: 0x4000001200       r01: 0xffff00000521d0f0 r02: 0xffff00403f001200
r03: 0xffff00000d5ba000 r04: 0x00000001 r05: 0x00000000
r06: 0xffffffffffffffff r07: 0x00000020 r08: 0xffff00000d631cc0
r09: 0x00000000 r10: 0x00000000 r11: 0xffffffffffff
r12: 0xffffffffffff     r13: 0xffff000000000000 r14: 0x00000000
r15: 0x00000000 r16: 0x00000000 r17: 0x00000000
r18: 0x00000000 r19: 0x00000000 r20: 0x00000000
r21: 0x00000000 r22: 0x00000000 r23: 0x00000000
r24: 0xffff000003b29710 r25: 0xffffffffffffffff

Stack Trace:
  __check_object_size+0xac/0x1fc
  sk_attach_filter+0x88/0x364
  sock_setsockopt+0xe88/0x1320
  sys_setsockopt+0x160/0x1dc
  EV_Trap+0xe8/0xec
```

