### PR TITLE
ARCv2/ARCv3: Change soft irq number

### DIFF
--- a/arch/arc/include/asm/irq.h
+++ b/arch/arc/include/asm/irq.h
@@ -17,7 +17,7 @@
 /* Platform Independent IRQs */
 #ifndef CONFIG_ISA_ARCOMPACT
 #define IPI_IRQ		19
-#define SOFTIRQ_IRQ	21
+#define SOFTIRQ_IRQ	22
 #define FIRST_EXT_IRQ	24
 #endif
 


### PR DESCRIPTION
We have to change soft irq number to 22 since the previous number 21 now is occupied by CDMA. #23 is occupied by cluster PMU. 22 is the last unused by HW irq number from the proprietary static interrupts set.