### PR TITLE
ARC: Correction of uImage target build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
             libelf-dev \
             libncurses5-dev \
             libssl-dev \
+            u-boot-tools \
             make
 
       - name: Download toolchain
@@ -146,16 +147,15 @@ jobs:
             ;;
           esac
 
+          make -j $(nproc) uImage
+
           if [[ "${{ matrix.targets.cpu }}" =~ ^(hs5x|hs6x) ]]; then
-            image_name="loader"
-            image_path=${{ github.workspace }}/arch/arc/boot/loader
+            cp ${{ github.workspace }}/arch/arc/boot/loader vmlinux-${{ matrix.targets.cpu }}
           else
-            image_name="vmlinux"
-            image_path="${{ github.workspace }}/vmlinux"
+            cp ${{ github.workspace }}/vmlinux vmlinux-${{ matrix.targets.cpu }}
           fi
 
-          make -j $(nproc) ${image_name}
-          cp $image_path vmlinux-${{ matrix.targets.cpu }}
+          cp ${{ github.workspace }}/arch/arc/boot/uImage uImage-${{ matrix.targets.cpu }}
         shell: bash
 
       - name: Upload ${{ matrix.targets.cpu }} vmlinux
@@ -163,6 +163,13 @@ jobs:
         with:
           name: vmlinux-${{ matrix.targets.cpu }}
           path: vmlinux-${{ matrix.targets.cpu }}
+          retention-days: 5
+
+      - name: Upload ${{ matrix.targets.cpu }} uImage
+        uses: actions/upload-artifact@v3
+        with:
+          name: uImage-${{ matrix.targets.cpu }}
+          path: uImage-${{ matrix.targets.cpu }}
           retention-days: 5
 
   test:

--- a/arch/arc/boot/Makefile
+++ b/arch/arc/boot/Makefile
@@ -35,13 +35,25 @@ $(obj)/vmlinux.bin.gz: $(obj)/vmlinux.bin FORCE
 $(obj)/vmlinux.bin.lzma: $(obj)/vmlinux.bin FORCE
 	$(call if_changed,lzma)
 
+ifeq ($(CONFIG_ISA_ARCV3),y)
+$(obj)/uImage.bin: $(obj)/vmlinux.bin $(obj)/loader FORCE
+else
 $(obj)/uImage.bin: $(obj)/vmlinux.bin FORCE
+endif
 	$(call if_changed,uimage,none)
 
+ifeq ($(CONFIG_ISA_ARCV3),y)
+$(obj)/uImage.gz: $(obj)/vmlinux.bin.gz $(obj)/loader FORCE
+else
 $(obj)/uImage.gz: $(obj)/vmlinux.bin.gz FORCE
+endif
 	$(call if_changed,uimage,gzip)
 
+ifeq ($(CONFIG_ISA_ARCV3),y)
+$(obj)/uImage.lzma: $(obj)/vmlinux.bin.lzma $(obj)/loader FORCE
+else
 $(obj)/uImage.lzma: $(obj)/vmlinux.bin.lzma FORCE
+endif
 	$(call if_changed,uimage,lzma)
 
 $(obj)/loader.o: $(src)/loader.S $(obj)/vmlinux.bin


### PR DESCRIPTION
"uImage" target now have proper dependency on "loader". "make uImage" works properly.

Add a GitHub CI test builds to ci.yml for automated testing of uImage building.