### PR TITLE
ARCv3: Change address of MULTIPLY_BUILD from 0xC8 to 0x7B

### DIFF
--- a/arch/arc/include/asm/arcregs.h
+++ b/arch/arc/include/asm/arcregs.h
@@ -24,7 +24,6 @@
 #define ARC_REG_XY_MEM_BCR	0x79
 #define ARC_REG_MAC_BCR		0x7a
 #define ARC_REG_MPY_BCR		0x7b
-#define ARC_REG_MPY_ARC64_BCR	0xc8
 #define ARC_REG_SWAP_BCR	0x7c
 #define ARC_REG_NORM_BCR	0x7d
 #define ARC_REG_MIXMAX_BCR	0x7e

--- a/arch/arc/kernel/setup.c
+++ b/arch/arc/kernel/setup.c
@@ -320,7 +320,7 @@ static int arcv3_mumbojumbo(int c, struct cpuinfo_arc *info, char *buf, int len)
 	if (arc64) {
 		struct bcr_mpy_arc64 mpy;
 
-		READ_BCR(ARC_REG_MPY_ARC64_BCR, mpy);
+		READ_BCR(ARC_REG_MPY_BCR, mpy);
 		if (mpy.ver)
 			scnprintf(mpy_nm, 32, "mpy%s ", mpy.is64x64 ? " [64x64]" : "");
 


### PR DESCRIPTION
`MULTIPLY_BUILD` AUX register resides in `0x7B` for both ARCv2 and ARCv3. In turn, `0xC8` is occupied by `FPU_BUILD` and it's used correctly by the kernel.