### PR TITLE
ARCv2: Fix typos that lead to build error for big-endian targets

### DIFF
--- a/arch/arc/include/asm/cluster.h
+++ b/arch/arc/include/asm/cluster.h
@@ -60,7 +60,7 @@ struct bcr_cln_scm_0_cfg {
 	unsigned int res1:2, superblocks:3,
 		     data_bank_wid:2, data_sub_banks:2, cache_sets:5,
 		     data_bank_sz:5, data_banks:3, cache_tag_banks:3,
-		     cache_blk_sz:1 cache_assoc:4, scm_cache:1, res:1;
+		     cache_blk_sz:1, cache_assoc:4, scm_cache:1, res:1;
 #else
 	unsigned int res:1, scm_cache:1, cache_assoc:4, cache_blk_sz:1,
 		     cache_tag_banks:3, data_banks:3, data_bank_sz:5,

--- a/arch/arc/include/asm/perf_slc.h
+++ b/arch/arc/include/asm/perf_slc.h
@@ -47,7 +47,7 @@ struct slc_build {
 
 struct slc_aux_cache_config {
 #ifdef CONFIG_CPU_BIG_ENDIAN
-	u32 r:2, b:1, pm_num:5, pms:2, tag_time:4, tbank:3, data_time:4, dbank:3, ways:2 \
+	u32 r:2, b:1, pm_num:5, pms:2, tag_time:4, tbank:3, data_time:4, dbank:3, ways:2, \
         lsz:2, cache_sz:4;
 #else
 	u32 cache_sz:4, lsz:2, ways:2, dbank:3, data_time:4, tbank:3, tag_time:4, pms:2, \


### PR DESCRIPTION
The code to be fixed is not presented in upstream,