### PR TITLE
ptrace: Fix r13 register value retrieval.

### DIFF
--- a/arch/arc/kernel/ptrace.c
+++ b/arch/arc/kernel/ptrace.c
@@ -69,7 +69,7 @@ static int genregs_get(struct task_struct *target,
 	membuf_store(&to, cregs->r15);
 	membuf_store(&to, cregs->r14);
 #ifdef CONFIG_ISA_ARCV3
-	membuf_store(&to, &ptregs->r13);
+	membuf_store(&to, ptregs->r13);
 #else
 	membuf_store(&to, cregs->r13);
 #endif


### PR DESCRIPTION
It is intended to obtain the value stored in the r13 register. However, due to a misplaced "&" operator, it inadvertently retrieves the memory address associated with the r13 register.