### PR TITLE
CI: workflow for 'abrodkin-arc64-5.15.y' branch triggered by 'push'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [arc64]
+    branches: [arc64, abrodkin-arc64-5.15.y]
   pull_request:
-    branches: [arc64]
+    branches: [arc64, abrodkin-arc64-5.15.y]
 
   workflow_dispatch:
 


### PR DESCRIPTION
As discussed with @pavelvkozlov, I added the `abrodkin-arc64-5.15.y` branch to the CI process.