### PR TITLE
CI: Update toolchain to ARC 2023.09-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         targets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  toolchain_ver: 2022.09-rc2
+  toolchain_ver: 2023.09
   toolchain_url: https://github.com/foss-for-synopsys-dwc-arc-processors/arc-gnu-toolchain/releases/download/$toolchain_ver
 
 jobs:


### PR DESCRIPTION
Use ARC GNU Toolchain 2023.09-release for CI