### PR TITLE
CI: Bump the Ubuntu image version to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         targets:


### PR DESCRIPTION
ARC GNU Toolchain 2023.09 (https://github.com/foss-for-synopsys-dwc-arc-processors/arc-gnu-toolchain) was built inside latest (22.04) Ubuntu container, that's why Linux depends on more fresh glibc shared libraries and there are probably other dependencies. This commit explicitly sets the environment version to exlude extra build errors. The environment version may be changed later as the project progresses.