### PR TITLE
ARCv3: r13 register changes in accordance with ABI

### DIFF
--- a/arch/arc/include/uapi/asm/ptrace.h
+++ b/arch/arc/include/uapi/asm/ptrace.h
@@ -37,13 +37,21 @@ struct user_regs_struct {
 	struct {
 		unsigned long bta, lp_start, lp_end, lp_count;
 		unsigned long status32, ret, blink, fp, gp;
+#ifdef __ARC64__
+		unsigned long r13, r12, r11, r10, r9, r8, r7, r6, r5, r4, r3, r2, r1, r0;
+#else
 		unsigned long r12, r11, r10, r9, r8, r7, r6, r5, r4, r3, r2, r1, r0;
+#endif
 		unsigned long sp;
 	} scratch;
 	unsigned long pad2;
 	struct {
 		unsigned long r25, r24, r23, r22, r21, r20;
+#ifdef __ARC64__
+		unsigned long r19, r18, r17, r16, r15, r14;
+#else
 		unsigned long r19, r18, r17, r16, r15, r14, r13;
+#endif
 	} callee;
 	unsigned long efa;	/* break pt addr, for break points in delay slots */
 	unsigned long stop_pc;	/* give dbg stop_pc after ensuring brkpt trap */

--- a/arch/arc/kernel/ptrace.c
+++ b/arch/arc/kernel/ptrace.c
@@ -41,6 +41,9 @@ static int genregs_get(struct task_struct *target,
 	membuf_store(&to, ptregs->blink);
 	membuf_store(&to, ptregs->fp);
 	membuf_store(&to, ptregs->gp);
+#ifdef CONFIG_ISA_ARCV3
+	membuf_store(&to, ptregs->r13);
+#endif
 	membuf_store(&to, ptregs->r12);
 	membuf_store(&to, ptregs->r11);
 	membuf_store(&to, ptregs->r10);
@@ -68,9 +71,7 @@ static int genregs_get(struct task_struct *target,
 	membuf_store(&to, cregs->r16);
 	membuf_store(&to, cregs->r15);
 	membuf_store(&to, cregs->r14);
-#ifdef CONFIG_ISA_ARCV3
-	membuf_store(&to, ptregs->r13);
-#else
+#ifndef CONFIG_ISA_ARCV3
 	membuf_store(&to, cregs->r13);
 #endif
 	membuf_store(&to, target->thread.fault_address); // efa
@@ -134,6 +135,9 @@ static int genregs_set(struct task_struct *target,
 	REG_IN_ONE(scratch.blink, &ptregs->blink);
 	REG_IN_ONE(scratch.fp, &ptregs->fp);
 	REG_IN_ONE(scratch.gp, &ptregs->gp);
+#ifdef CONFIG_ISA_ARCV3
+	REG_IN_ONE(scratch.r13, &ptregs->r13);
+#endif
 	REG_IN_ONE(scratch.r12, &ptregs->r12);
 	REG_IN_ONE(scratch.r11, &ptregs->r11);
 	REG_IN_ONE(scratch.r10, &ptregs->r10);
@@ -164,9 +168,7 @@ static int genregs_set(struct task_struct *target,
 	REG_IN_ONE(callee.r15, &cregs->r15);
 	REG_IN_ONE(callee.r14, &cregs->r14);
 
-#ifdef CONFIG_ISA_ARCV3
-	REG_IN_ONE(callee.r13, &ptregs->r13);
-#else
+#ifndef CONFIG_ISA_ARCV3
 	REG_IN_ONE(callee.r13, &cregs->r13);
 #endif
 

--- a/arch/arc/kernel/signal.c
+++ b/arch/arc/kernel/signal.c
@@ -129,6 +129,9 @@ stash_usr_regs(struct rt_sigframe __user *sf, struct pt_regs *regs,
 	uregs.scratch.blink	= regs->blink;
 	uregs.scratch.fp	= regs->fp;
 	uregs.scratch.gp	= regs->gp;
+#ifdef CONFIG_ISA_ARCV3
+	uregs.scratch.r13	= regs->r13;
+#endif
 	uregs.scratch.r12	= regs->r12;
 	uregs.scratch.r11	= regs->r11;
 	uregs.scratch.r10	= regs->r10;
@@ -147,7 +150,7 @@ stash_usr_regs(struct rt_sigframe __user *sf, struct pt_regs *regs,
 	err = __copy_to_user(&(sf->uc.uc_mcontext.regs.scratch), &uregs.scratch,
 			     sizeof(sf->uc.uc_mcontext.regs.scratch));
 
-	if (is_isa_arcv2())
+	if (!is_isa_arcompact())
 		err |= save_arcv2_regs(&(sf->uc.uc_mcontext), regs);
 
 	err |= __copy_to_user(&sf->uc.uc_sigmask, set, sizeof(sigset_t));
@@ -166,7 +169,7 @@ static int restore_usr_regs(struct pt_regs *regs, struct rt_sigframe __user *sf)
 				&(sf->uc.uc_mcontext.regs.scratch),
 				sizeof(sf->uc.uc_mcontext.regs.scratch));
 
-	if (is_isa_arcv2())
+	if (!is_isa_arcompact())
 		err |= restore_arcv2_regs(&(sf->uc.uc_mcontext), regs);
 
 	if (err)
@@ -184,6 +187,9 @@ static int restore_usr_regs(struct pt_regs *regs, struct rt_sigframe __user *sf)
 	regs->blink	= uregs.scratch.blink;
 	regs->fp	= uregs.scratch.fp;
 	regs->gp	= uregs.scratch.gp;
+#ifdef CONFIG_ISA_ARCV3
+	regs->r13	= uregs.scratch.r13;
+#endif
 	regs->r12	= uregs.scratch.r12;
 	regs->r11	= uregs.scratch.r11;
 	regs->r10	= uregs.scratch.r10;


### PR DESCRIPTION
For the ARCv3 architecture, changes have occurred regarding the r13 registry in the ABI. Now register r13 from callee saved has become a scratch register. This patch moves r13 in the corresponding structures and makes changes in functions for proper saving and restoring user context.